### PR TITLE
Update pre-commit config and .isort.cfg

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,3 @@
 [settings]
-known_third_party=pkg_resources,pytest
+profile = black
 multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -11,21 +11,22 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
+        args: ["--skip-string-normalization"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.961
     hooks:
       - id: mypy
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.6.4
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
- Update pre-commit hooks with `pre-commit autoupdate`.
- Add a "--skip-string-normalization" flag for black to ensure it doesn't
  remove python2-specific u"foo" from tests.
- Update .isort.cfg with new simplified black-compatible rules.
